### PR TITLE
Fixed map replacement crash, and added some extra debug output

### DIFF
--- a/flatland_server/src/body.cpp
+++ b/flatland_server/src/body.cpp
@@ -66,7 +66,13 @@ Body::Body(b2World *physics_world, Entity *entity, const std::string &name,
 }
 
 Body::~Body() {
+  ROS_INFO_NAMED("Body",
+                 "body  \"%s\" destructor called",
+                 name_.c_str());
   if (physics_body_) {
+    ROS_INFO_NAMED("Body",
+                   "Deleting physics body for \"%s\"",
+                   name_.c_str());
     physics_body_->GetWorld()->DestroyBody(physics_body_);
   }
 }

--- a/flatland_server/src/layer.cpp
+++ b/flatland_server/src/layer.cpp
@@ -118,7 +118,12 @@ Layer::Layer(b2World *physics_world, CollisionFilterRegistry *cfr,
       cfr_(cfr),
       viz_name_("layer/" + names[0]) {}
 
-Layer::~Layer() { delete body_; }
+Layer::~Layer() { 
+  ROS_INFO_NAMED("Layer",
+                 "layer \"%s\" destructor called",
+                 names_[0].c_str());
+  delete body_; 
+}
 
 const std::vector<std::string> &Layer::GetNames() const { return names_; }
 

--- a/flatland_server/src/simulation_manager.cpp
+++ b/flatland_server/src/simulation_manager.cpp
@@ -238,13 +238,11 @@ bool SimulationManager::callback_StepWorld(
 // void SimulationManager::callback(nav_msgs::OccupancyGrid msg) {
 // void SimulationManager::callback(geometry_msgs::PoseStamped msg) {
 void SimulationManager::callback(const std_msgs::String::ConstPtr& msg) {
+    std::string map_layer_yaml_file_(msg->data);
     YamlReader world_reader = YamlReader(map_layer_yaml_file_);
     YamlReader layers_reader = world_reader.Subnode("layers", YamlReader::LIST);
-    world_->layers_name_map_.clear();
-    world_->layers_.clear();
-    ROS_INFO_NAMED("World", "Layer cleared");
-    world_->cfr_.layer_id_table_.clear();
-    ROS_INFO_NAMED("World", "Layer ID table cleared");
+
+    // replace the existing world layers with layers loaded from the provided yaml file
     world_->LoadLayers(layers_reader);
     world_->DebugVisualize(true);
     ROS_INFO_NAMED("World", "Map Layer loaded");


### PR DESCRIPTION
I changed the way that map layer reloading is done to avoid causing problems for the collision filter registry.

The collision filter registry creates a map of layer names to collision filter IDs, which correspond to box2d's bitfield collision filtering. When layers are loaded, their names are assigned collision filter ids (0-15), and when models are loaded, their physics bodies are assigned corresponding bitmasks. Changing that mapping mid-run is not currently handled, since it would require re-calculating the CFR bitmasks for all active physics bodies (layers and models). This is possible to implement, but fairly complicated to do.

Instead, when a new set of layers is loaded, the CFR is maintained unchanged. New layer **names** get new CFR entries, but if the name already exists, the CFR is not changed. Instead, the existing layer is deleted, and then it's replacement is loaded.

If a layer doesn't exist in the new layer list, it's flagged for deletion, but because the CFR doesn't handle deletion gracefully in the current code, the layer is left alone, but it's contents is cleared (which clears the visualization and box2d entities for that layer).

I've tested loading between two different world files about 40 times (repeat loading the same world, and switching back and forth), and this seems stable. Let me know if it works for your use case!